### PR TITLE
Fix spelling mistake of knockout

### DIFF
--- a/ko.applyBidnings.sublime-snippet
+++ b/ko.applyBidnings.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[ko.applyBindings(${1:vm}, ${2:element});]]></content>
 	<tabTrigger>ko.apply</tabTrigger>
 	<scope>source.js</scope>
-	<description>kockoutjs apply bindings</description>
+	<description>knockoutjs apply bindings</description>
 </snippet>

--- a/ko.dependentObservable.sublime-snippet
+++ b/ko.dependentObservable.sublime-snippet
@@ -4,5 +4,5 @@
 \}, ${1:this});]]></content>
 	<tabTrigger>ko.dep</tabTrigger>
 	<scope>source.js</scope>
-	<description>kockoutjs dependent observable</description>
+	<description>knockoutjs dependent observable</description>
 </snippet>

--- a/ko.observable.sublime-snippet
+++ b/ko.observable.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[ko.observable($0);]]></content>
 	<tabTrigger>ko.o</tabTrigger>
 	<scope>source.js</scope>
-	<description>kockoutjs observable</description>
+	<description>knockoutjs observable</description>
 </snippet>

--- a/ko.observableArray.sublime-snippet
+++ b/ko.observableArray.sublime-snippet
@@ -2,5 +2,5 @@
 	<content><![CDATA[ko.observableArray($0);]]></content>
 	<tabTrigger>ko.[]</tabTrigger>
 	<scope>source.js</scope>
-	<description>kockoutjs observable array</description>
+	<description>knockoutjs observable array</description>
 </snippet>

--- a/simple-viewModel.sublime-snippet
+++ b/simple-viewModel.sublime-snippet
@@ -4,5 +4,5 @@
 	};]]></content>
 	<tabTrigger>ko.vm</tabTrigger>
 	<scope>source.js</scope>
-	<description>simple kockoutjs viewModel</description>
+	<description>simple knockoutjs viewModel</description>
 </snippet>


### PR DESCRIPTION
all instances of "kockout" has been replaced with "knockout"
